### PR TITLE
fix: align filters, tags, and forms with backend issue schema

### DIFF
--- a/ai-use-log.md
+++ b/ai-use-log.md
@@ -43,6 +43,7 @@
 - still hand checked to verify everything and handwrote all of the comments for toggle password.
 Amberly:
 - fix linting 
+- used ai to help with getting LLM response
 
 
 ---

--- a/frontend/css/global.css
+++ b/frontend/css/global.css
@@ -392,25 +392,13 @@ select.input:focus-visible {
 	border-color: oklch(88% 0.05 30deg);
 }
 
-.chip.tag-ui {
+.chip.tag-feature {
 	color: oklch(50% 0.13 280deg);
 	background: oklch(97% 0.025 280deg);
 	border-color: oklch(88% 0.05 280deg);
 }
 
-.chip.tag-infra {
-	color: oklch(50% 0.11 200deg);
-	background: oklch(97% 0.025 200deg);
-	border-color: oklch(88% 0.05 200deg);
-}
-
-.chip.tag-auth {
-	color: oklch(50% 0.13 320deg);
-	background: oklch(97% 0.025 320deg);
-	border-color: oklch(88% 0.05 320deg);
-}
-
-.chip.tag-perf {
+.chip.tag-task {
 	color: oklch(50% 0.13 130deg);
 	background: oklch(97% 0.025 130deg);
 	border-color: oklch(88% 0.05 130deg);

--- a/frontend/css/tracker.css
+++ b/frontend/css/tracker.css
@@ -443,23 +443,16 @@ body {
 	background: currentcolor;
 }
 
-.nav-item .ic.label-bug {
+.nav-item .ic.label-bug,
+.filter-item .indicator.label-bug {
 	color: oklch(50% 0.13 30deg);
 }
 
-.nav-item .ic.label-ui {
+.filter-item .indicator.label-feature {
 	color: oklch(50% 0.13 280deg);
 }
 
-.nav-item .ic.label-infra {
-	color: oklch(50% 0.11 200deg);
-}
-
-.nav-item .ic.label-auth {
-	color: oklch(50% 0.13 320deg);
-}
-
-.nav-item .ic.label-perf {
+.filter-item .indicator.label-task {
 	color: oklch(50% 0.13 130deg);
 }
 
@@ -491,6 +484,17 @@ body {
 
 .sidebar .members .avatar:first-child {
 	margin-left: 0;
+}
+
+.team-section .team-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0 6px 6px;
+}
+
+.team-section .invite-btn {
+	flex-shrink: 0;
 }
 
 .skill-card {
@@ -701,7 +705,7 @@ body {
 
 .issue-row {
 	display: grid;
-	grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+	grid-template-columns: minmax(0, 1fr) auto auto auto;
 	align-items: center;
 	gap: 12px;
 	padding: 10px 18px;
@@ -717,43 +721,6 @@ body {
 .issue-row.selected {
 	background: var(--accent-soft);
 	box-shadow: inset 2px 0 0 var(--accent);
-}
-
-.issue-row .pri-mark {
-	width: 18px;
-	height: 18px;
-	border-radius: 4px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	font-family: var(--mono);
-	font-size: 9px;
-	font-weight: 700;
-	letter-spacing: 0;
-}
-
-.pri-mark.urgent {
-	background: oklch(95% 0.05 25deg);
-	color: var(--pri-urgent);
-	border: 1px solid oklch(85% 0.06 25deg);
-}
-
-.pri-mark.high {
-	background: oklch(95% 0.045 38deg);
-	color: var(--pri-high);
-	border: 1px solid oklch(85% 0.06 38deg);
-}
-
-.pri-mark.med {
-	background: oklch(96% 0.04 80deg);
-	color: var(--pri-med);
-	border: 1px solid oklch(86% 0.06 80deg);
-}
-
-.pri-mark.low {
-	background: oklch(95% 0.03 230deg);
-	color: var(--pri-low);
-	border: 1px solid oklch(85% 0.05 230deg);
 }
 
 .issue-row .id {

--- a/frontend/css/tracker.css
+++ b/frontend/css/tracker.css
@@ -443,35 +443,6 @@ body {
 	background: currentcolor;
 }
 
-.nav-item .ic.label-bug,
-.filter-item .indicator.label-bug {
-	color: oklch(50% 0.13 30deg);
-}
-
-.filter-item .indicator.label-feature {
-	color: oklch(50% 0.13 280deg);
-}
-
-.filter-item .indicator.label-task {
-	color: oklch(50% 0.13 130deg);
-}
-
-.filter-item .indicator.label-ui {
-	color: oklch(50% 0.13 250deg);
-}
-
-.filter-item .indicator.label-infra {
-	color: oklch(50% 0.1 60deg);
-}
-
-.filter-item .indicator.label-auth {
-	color: oklch(50% 0.13 320deg);
-}
-
-.filter-item .indicator.label-perf {
-	color: oklch(50% 0.13 200deg);
-}
-
 .nav-item.pri-urgent {
 	color: var(--pri-urgent);
 }

--- a/frontend/css/tracker.css
+++ b/frontend/css/tracker.css
@@ -791,7 +791,6 @@ body {
 .issue-row .updated {
 	font-size: 11.5px;
 	color: var(--muted);
-	font-family: var(--mono);
 	text-align: center;
 }
 
@@ -1059,4 +1058,17 @@ body {
 	margin: 0 0 8px;
 	font-size: 14px;
 	font-weight: 600;
+}
+
+/* Detail pane section bodies — preserve line breaks from Description / LLM text */
+.issue-section-body {
+	white-space: pre-wrap;
+	line-height: 1.55;
+	margin: 8px 0 0;
+	font-size: 14px;
+}
+
+/* Ordered list when steps_to_reproduce is stored as a JSON array */
+.issue-steps {
+	padding-left: 1.25rem;
 }

--- a/frontend/css/tracker.css
+++ b/frontend/css/tracker.css
@@ -456,6 +456,22 @@ body {
 	color: oklch(50% 0.13 130deg);
 }
 
+.filter-item .indicator.label-ui {
+	color: oklch(50% 0.13 250deg);
+}
+
+.filter-item .indicator.label-infra {
+	color: oklch(50% 0.1 60deg);
+}
+
+.filter-item .indicator.label-auth {
+	color: oklch(50% 0.13 320deg);
+}
+
+.filter-item .indicator.label-perf {
+	color: oklch(50% 0.13 200deg);
+}
+
 .nav-item.pri-urgent {
 	color: var(--pri-urgent);
 }

--- a/frontend/html/tracker.html
+++ b/frontend/html/tracker.html
@@ -94,6 +94,7 @@
 			<aside class="sidebar">
 				<!-- Removed "Views" Nav Section  -->
 
+				<!-- Status filters match backend values one-to-one (Resolved and Closed are separate). -->
 				<div class="nav-section">
 					<div class="label-sm">STATUS</div>
 					<!-- Items use .active and .indicator to drive the filled circle logic -->
@@ -104,49 +105,32 @@
 						<span class="indicator"></span> In progress <span class="count" id="cnt-prog">0</span>
 					</div>
 					<div class="filter-item" data-group="status" data-val="Resolved">
-						<span class="indicator"></span> Done <span class="count" id="cnt-done">0</span>
+						<span class="indicator"></span> Resolved <span class="count" id="cnt-resolved">0</span>
+					</div>
+					<div class="filter-item" data-group="status" data-val="Closed">
+						<span class="indicator"></span> Closed <span class="count" id="cnt-closed">0</span>
 					</div>
 				</div>
 
-				<div class="nav-section">
-					<div class="label-sm">PRIORITY</div>
-					<div class="filter-item pri-urgent" data-group="priority" data-val="Critical">
-						<span class="indicator"></span> Urgent <span class="count" id="cnt-crit">0</span>
-					</div>
-					<div class="filter-item pri-high" data-group="priority" data-val="High">
-						<span class="indicator"></span> High <span class="count" id="cnt-high">0</span>
-					</div>
-					<div class="filter-item pri-med" data-group="priority" data-val="Medium">
-						<span class="indicator"></span> Medium <span class="count" id="cnt-med">0</span>
-					</div>
-					<div class="filter-item pri-low" data-group="priority" data-val="Low">
-						<span class="indicator"></span> Low <span class="count" id="cnt-low">0</span>
-					</div>
-				</div>
-
+				<!-- Tag filters use the same bug / feature / task values stored on issue.tags -->
 				<div class="nav-section">
 					<div class="label-sm">TAGS</div>
 					<div class="filter-item" data-group="tag" data-val="bug">
 						<span class="indicator label-bug"></span> bug <span class="count" id="cnt-bug">0</span>
 					</div>
-					<div class="filter-item" data-group="tag" data-val="ui">
-						<span class="indicator label-ui"></span> ui <span class="count" id="cnt-ui">0</span>
+					<div class="filter-item" data-group="tag" data-val="feature">
+						<span class="indicator label-feature"></span> feature <span class="count" id="cnt-feature">0</span>
 					</div>
-					<div class="filter-item" data-group="tag" data-val="infra">
-						<span class="indicator label-infra"></span> infra <span class="count" id="cnt-infra">0</span>
-					</div>
-					<div class="filter-item" data-group="tag" data-val="auth">
-						<span class="indicator label-auth"></span> auth <span class="count" id="cnt-auth">0</span>
-					</div>
-					<div class="filter-item" data-group="tag" data-val="perf">
-						<span class="indicator label-perf"></span> perf <span class="count" id="cnt-perf">0</span>
+					<div class="filter-item" data-group="tag" data-val="task">
+						<span class="indicator label-task"></span> task <span class="count" id="cnt-task">0</span>
 					</div>
 				</div>
 
-				<div class="nav-section">
-					<div class="label-sm" style="display: flex; justify-content: space-between; align-items: center">
-						<span>Team</span>
-						<button class="btn ghost sm" id="open-invite-modal" style="padding: 0 6px" title="Invite user">+</button>
+				<!-- Compact invite control sits on the same row as the Team label -->
+				<div class="nav-section team-section">
+					<div class="team-header">
+						<span class="label-sm">Team</span>
+						<button class="btn sm invite-btn" id="open-invite-modal" type="button" title="Invite user">Invite user</button>
 					</div>
 					<div class="members"></div>
 				</div>
@@ -177,9 +161,9 @@
 						<div class="filter-group">
 							<span class="label-sm">SORT</span>
 							<!-- Multiple sort triggers -->
+							<!-- Client-side sort only; priority is not filtered in the sidebar -->
 							<button class="sort-btn on" data-sort="priority">priority <span class="arrow">↓</span></button>
 							<button class="sort-btn" data-sort="updated">updated</button>
-							<button class="sort-btn" data-sort="difficulty">difficulty</button>
 						</div>
 					</div>
 
@@ -224,11 +208,12 @@
 							</select>
 						</div>
 						<div class="field" style="flex: 1; margin-bottom: 0">
-							<label>Category</label>
-							<select class="input" id="new-category">
-								<option value="Bug">Bug</option>
-								<option value="Feature">Feature</option>
-								<option value="Task">Task</option>
+							<!-- Tag is written to tags[] and mapped to backend category via TAG_MAP -->
+							<label>Tag</label>
+							<select class="input" id="new-tag">
+								<option value="bug">bug</option>
+								<option value="feature">feature</option>
+								<option value="task">task</option>
 							</select>
 						</div>
 						<div class="field" style="flex: 1; margin-bottom: 0">
@@ -236,17 +221,6 @@
 							<select class="input" id="new-assignee">
 								<option value="">Unassigned</option>
 							</select>
-						</div>
-					</div>
-
-					<div style="display: flex; gap: 12px; margin-bottom: 12px">
-						<div class="field" style="flex: 1; margin-bottom: 0">
-							<label>Difficulty (1-3)</label>
-							<input type="number" class="input" id="new-difficulty" min="1" max="3" placeholder="e.g. 2" />
-						</div>
-						<div class="field" style="flex: 2; margin-bottom: 0">
-							<label>Tags (comma separated)</label>
-							<input type="text" class="input" id="new-tags" placeholder="ui, bug, frontend" />
 						</div>
 					</div>
 					<div class="field">

--- a/frontend/html/tracker.html
+++ b/frontend/html/tracker.html
@@ -112,18 +112,10 @@
 					</div>
 				</div>
 
-				<!-- Tag filters use the same bug / feature / task values stored on issue.tags -->
+				<!-- Tag filters rendered from TAGS in constants.js -->
 				<div class="nav-section">
 					<div class="label-sm">TAGS</div>
-					<div class="filter-item" data-group="tag" data-val="bug">
-						<span class="indicator label-bug"></span> bug <span class="count" id="cnt-bug">0</span>
-					</div>
-					<div class="filter-item" data-group="tag" data-val="feature">
-						<span class="indicator label-feature"></span> feature <span class="count" id="cnt-feature">0</span>
-					</div>
-					<div class="filter-item" data-group="tag" data-val="task">
-						<span class="indicator label-task"></span> task <span class="count" id="cnt-task">0</span>
-					</div>
+					<div id="tag-filters"></div>
 				</div>
 
 				<!-- Compact invite control sits on the same row as the Team label -->
@@ -210,11 +202,7 @@
 						<div class="field" style="flex: 1; margin-bottom: 0">
 							<!-- Tag is written to tags[] and mapped to backend category via TAG_MAP -->
 							<label>Tag</label>
-							<select class="input" id="new-tag">
-								<option value="bug">bug</option>
-								<option value="feature">feature</option>
-								<option value="task">task</option>
-							</select>
+							<select class="input" id="new-tag"></select>
 						</div>
 						<div class="field" style="flex: 1; margin-bottom: 0">
 							<label>Assignee</label>

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -12,7 +12,19 @@ export const STATUS_NAME = {
 export const SKILLS_MD = `# skills.md - Issue Tracker agent guide...`;
 
 // Standard list of tags
-export const TAGS = ['ui', 'backend','database', 'authentication', 'performance', 'security', 'testing', 'documentation', 'integration', 'enhancement', 'research'];
+export const TAGS = [
+	'ui',
+	'backend',
+	'database',
+	'authentication',
+	'performance',
+	'security',
+	'testing',
+	'documentation',
+	'integration',
+	'enhancement',
+	'research',
+];
 
 /** Maps sidebar tag to backend category enum (Bug | Feature | Task).
  * Temporary until backend fix
@@ -28,7 +40,7 @@ export const TAG_MAP = {
 	documentation: 'Bug',
 	integration: 'Bug',
 	enhancement: 'Bug',
-	research: 'Bug'
+	research: 'Bug',
 };
 
 // Predefined "Views" (Saved filter/sort combinations)

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -12,15 +12,23 @@ export const STATUS_NAME = {
 export const SKILLS_MD = `# skills.md - Issue Tracker agent guide...`;
 
 // Standard list of tags
-export const TAGS = ['bug', 'ui', 'infra', 'auth', 'perf'];
+export const TAGS = ['ui', 'backend','database', 'authentication', 'performance', 'security', 'testing', 'documentation', 'integration', 'enhancement', 'research'];
 
-/** Maps sidebar tag to backend category enum (Bug | Feature | Task). */
+/** Maps sidebar tag to backend category enum (Bug | Feature | Task).
+ * Temporary until backend fix
+ */
 export const TAG_MAP = {
-	bug: 'Bug',
 	ui: 'Bug',
-	auth: 'Bug',
-	perf: 'Bug',
-	infra: 'Task',
+	backend: 'Bug',
+	database: 'Bug',
+	authentication: 'Bug',
+	performance: 'Bug',
+	security: 'Bug',
+	testing: 'Bug',
+	documentation: 'Bug',
+	integration: 'Bug',
+	enhancement: 'Bug',
+	research: 'Bug'
 };
 
 // Predefined "Views" (Saved filter/sort combinations)

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -11,8 +11,11 @@ export const STATUS_NAME = {
 
 export const SKILLS_MD = `# skills.md - Issue Tracker agent guide...`;
 
-// Standard list of tags
-export const TAGS = ['bug', 'ui', 'infra', 'auth', 'perf'];
+// Standard issue-type tags shown in the sidebar, list, and create/edit forms.
+export const TAGS = ['bug', 'feature', 'task'];
+
+// Backend stores category as Title Case; UI tags stay lowercase.
+export const TAG_MAP = { bug: 'Bug', feature: 'Feature', task: 'Task' };
 
 // Predefined "Views" (Saved filter/sort combinations)
 export const DEFAULT_VIEWS = [

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -11,11 +11,17 @@ export const STATUS_NAME = {
 
 export const SKILLS_MD = `# skills.md - Issue Tracker agent guide...`;
 
-// Standard issue-type tags shown in the sidebar, list, and create/edit forms.
-export const TAGS = ['bug', 'feature', 'task'];
+// Standard list of tags
+export const TAGS = ['bug', 'ui', 'infra', 'auth', 'perf'];
 
-// Backend stores category as Title Case; UI tags stay lowercase.
-export const TAG_MAP = { bug: 'Bug', feature: 'Feature', task: 'Task' };
+/** Maps sidebar tag to backend category enum (Bug | Feature | Task). */
+export const TAG_MAP = {
+	bug: 'Bug',
+	ui: 'Bug',
+	auth: 'Bug',
+	perf: 'Bug',
+	infra: 'Task',
+};
 
 // Predefined "Views" (Saved filter/sort combinations)
 export const DEFAULT_VIEWS = [

--- a/frontend/js/tracker.js
+++ b/frontend/js/tracker.js
@@ -204,6 +204,7 @@ function renderList() {
 	listEl.querySelectorAll('.issue-row').forEach((el) => {
 		el.addEventListener('click', () => {
 			state.selected = Number(el.dataset.id);
+			state.isEditing = false;
 			renderList();
 			renderDetail();
 			// Selection should reveal the pane; otherwise a row click can look
@@ -295,6 +296,127 @@ function renderTeamMembers() {
 	membersContainer.innerHTML = membersHtml;
 }
 
+// === Date Formatting === //
+/** 
+ * @param {string | null | undefined} value
+ * @returns {Date | null}
+ */
+function parseIssueTimestamp(value) {
+	if (!value) return null;
+	const normalized = value.includes('T') ? value : `${value.replace(' ', 'T')}Z`;
+	const date = new Date(normalized);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function formatIssueDate(value) {
+	const date = parseIssueTimestamp(value);
+	if (!date) return value || '—';
+
+	const now = new Date();
+	const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+	const dayDiff = Math.round((startOfToday - startOfDate) / 86400000);
+
+	if (dayDiff === 0) return 'Today';
+	if (dayDiff === 1) return 'Yesterday';
+
+	return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function formatIssueDateTime(value) {
+	const date = parseIssueTimestamp(value);
+	if (!date) return value || '';
+
+	return new Intl.DateTimeFormat(undefined, {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+	}).format(date);
+}
+
+// === Issue detail display (view pane) === //
+// Summary, Hypothesis, and Steps come from LLM enrichment; Details is the user's create-form description.
+
+/**
+ * Escape user/LLM text before inserting into detail pane HTML.
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+	return String(text)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+/**
+ * Plain-text section body with fallback when LLM/user field is empty.
+ * @param {string | null | undefined} value
+ * @param {string} [fallback='Not available yet']
+ * @returns {string}
+ */
+function formatIssueText(value, fallback = 'Not available yet') {
+	if (value == null) return fallback;
+	const text = (typeof value === 'string' ? value : String(value)).trim();
+	if (!text || text.toLowerCase() === 'null') return fallback;
+	return escapeHtml(text);
+}
+
+/**
+ * Merges LLM-enriched fields from POST /issues into an in-memory issue record.
+ * @param {object} issue
+ * @param {object} enriched
+ * @returns {object}
+ */
+function applyEnrichedFields(issue, enriched) {
+	return {
+		...issue,
+		summary: enriched.summary ?? issue.summary,
+		hypothesis: enriched.hypothesis ?? issue.hypothesis,
+		steps_to_reproduce: enriched.steps_to_reproduce ?? issue.steps_to_reproduce,
+	};
+}
+
+/**
+ * Render steps_to_reproduce — API may store plain text or a JSON array string.
+ * @param {string | string[] | null | undefined} value
+ * @returns {string}
+ */
+function formatStepsToReproduce(value) {
+	if (value == null || value === '') return 'Not available yet';
+
+	let steps = value;
+	if (typeof value === 'string') {
+		try {
+			const parsed = JSON.parse(value);
+			if (Array.isArray(parsed)) steps = parsed;
+		} catch {
+			// Not JSON — treat as a single plain-text block from the LLM
+			return `<p class="issue-section-body">${escapeHtml(value.trim())}</p>`;
+		}
+	}
+
+	if (Array.isArray(steps)) {
+		const items = steps.map((s) => String(s).trim()).filter(Boolean);
+		if (items.length === 0) return 'Not available yet';
+		return `<ol class="issue-section-body issue-steps">${items.map((s) => `<li>${escapeHtml(s)}</li>`).join('')}</ol>`;
+	}
+
+	const text = String(steps).trim();
+	return text ? `<p class="issue-section-body">${escapeHtml(text)}</p>` : 'Not available yet';
+}
+
 /**
  * Build HTML for a single issue row in the list.
  * @param {object} i - Issue record.
@@ -322,7 +444,7 @@ function rowHtml(i) {
 		</div>
 		<div class="labels">${tagsHtml}</div>
 		<span class="chip st-${statusKey}">${STATUS_NAME[i.status]}</span>
-		<span class="updated">${i.updated_at}</span>
+		<span class="updated" title="${formatIssueDateTime(i.updated_at)}">${formatIssueDate(i.updated_at)}</span>
 	</div>`;
 }
 
@@ -350,10 +472,11 @@ function renderDetail() {
 	// Implementation of View vs Edit Mode
 	if (!state.isEditing) {
 		// --- VIEW MODE ---
+		// Sections: Summary / Steps / Hypothesis (LLM) + Details (user description on create)
 		detailEl.innerHTML = `
 			<div class="issue-details-header">
 				<h1 class="h-2" style="margin:0">${i.title}</h1>
-				<button class="btn sm edit-issue-btn" title="Edit Issue">✎</button>
+				<button type="button" class="btn sm edit-issue-btn" title="Edit Issue">✎</button>
 			</div>
 			
 			<div class="details-meta-grid">
@@ -384,21 +507,29 @@ function renderDetail() {
 			<div class="detail-body">
 				<div class="ai-content-block">
 					<span class="label-sm">Summary</span>
-					<p style="margin-top:8px">${i.summary || 'AI is generating a summary...'}</p>
+					<p class="issue-section-body">${formatIssueText(i.summary)}</p>
+				</div>
+				<div class="ai-content-block" style="margin-top:24px">
+					<span class="label-sm">Steps to reproduce</span>
+					${formatStepsToReproduce(i.steps_to_reproduce)}
 				</div>
 				<div class="ai-content-block" style="margin-top:24px">
 					<span class="label-sm">Hypothesis</span>
-					<p style="margin-top:8px">${i.description || 'No description provided.'}</p>
+					<p class="issue-section-body">${formatIssueText(i.hypothesis)}</p>
+				</div>
+				<div class="ai-content-block" style="margin-top:24px">
+					<span class="label-sm">Details</span>
+					<p class="issue-section-body">${formatIssueText(i.description, 'No description provided.')}</p>
 				</div>
 			</div>`;
 	} else {
-		// --- EDIT MODE (Edit Issue UI) ---
+		// --- EDIT MODE — human fields only; LLM sections stay read-only in view mode ---
 		detailEl.innerHTML = `
 			<div class="issue-details-header">
 				<input class="input h-2" id="edit-title" value="${i.title}" style="width: 70%">
 				<div class="actions">
-					<button class="btn sm" id="cancel-edit">Cancel</button>
-					<button class="btn sm primary" id="save-edit">Save</button>
+					<button type="button" class="btn sm" id="cancel-edit">Cancel</button>
+					<button type="button" class="btn sm primary" id="save-edit">Save</button>
 				</div>
 			</div>
 			
@@ -409,6 +540,7 @@ function renderDetail() {
 						<option ${i.status === 'Open' ? 'selected' : ''}>Open</option>
 						<option ${i.status === 'In Progress' ? 'selected' : ''}>In Progress</option>
 						<option ${i.status === 'Resolved' ? 'selected' : ''}>Resolved</option>
+						<option ${i.status === 'Closed' ? 'selected' : ''}>Closed</option>
 					</select>
 				</div>
 				<div class="meta-col">
@@ -423,8 +555,8 @@ function renderDetail() {
 			</div>
 
 			<div class="detail-body">
-				<span class="label-sm">Description</span>
-				<textarea class="textarea" id="edit-desc" style="margin-top:8px">${i.description}</textarea>
+				<span class="label-sm">Details</span>
+				<textarea class="textarea" id="edit-desc" style="margin-top:8px">${i.description || ''}</textarea>
 			</div>`;
 	}
 }
@@ -698,6 +830,13 @@ confirmNewBtn.addEventListener('click', async () => {
 
 		ISSUES = await fetchIssues(state.currentTeamId);
 
+		if (response?.id && response.enriched) {
+			const idx = ISSUES.findIndex((issue) => issue.id === response.id);
+			if (idx !== -1) {
+				ISSUES[idx] = applyEnrichedFields(ISSUES[idx], response.enriched);
+			}
+		}
+
 		if (response.id) {
 			state.selected = response.id;
 		} else {
@@ -777,15 +916,61 @@ document.addEventListener('keydown', (e) => {
 });
 
 detailEl.addEventListener('click', async (e) => {
-	//Toggle Edit Mode
-	if (e.target.matches('.edit-issue-btn')) {
+	const editBtn = e.target.closest('.edit-issue-btn');
+	if (editBtn) {
 		state.isEditing = true;
 		renderDetail();
+		return;
 	}
-	if (e.target.matches('#cancel-edit')) {
+
+	const cancelBtn = e.target.closest('#cancel-edit');
+	if (cancelBtn) {
 		state.isEditing = false;
 		renderDetail();
+		return;
 	}
+
+	const saveBtn = e.target.closest('#save-edit');
+	if (saveBtn) {
+		const currentIssue = ISSUES.find((issue) => issue.id === state.selected);
+		if (!currentIssue) return;
+
+		const title = document.getElementById('edit-title')?.value.trim();
+		const status = document.getElementById('edit-status')?.value;
+		const priority = document.getElementById('edit-priority')?.value;
+		const description = document.getElementById('edit-desc')?.value.trim();
+
+		if (!title || !description) {
+			showToast('Title and details are required');
+			return;
+		}
+
+		const updates = { title, status, priority, description };
+
+		saveBtn.textContent = 'Saving...';
+		saveBtn.disabled = true;
+		try {
+			await updateIssue(state.selected, updates);
+
+			if (state.currentTeamId) {
+				ISSUES = await fetchIssues(state.currentTeamId);
+			} else {
+				const index = ISSUES.findIndex((issue) => issue.id === state.selected);
+				if (index !== -1) ISSUES[index] = { ...ISSUES[index], ...updates };
+			}
+
+			state.isEditing = false;
+			renderList();
+			renderDetail();
+			showToast('Issue updated');
+		} catch {
+			showToast('Failed to save edits');
+			saveBtn.textContent = 'Save';
+			saveBtn.disabled = false;
+		}
+		return;
+	}
+
 	// Fix close details blank page
 	// If your "Back" or "Details" toggle clears selection, ensure it re-renders
 	if (e.target.id === 'toggle-detail') {
@@ -810,50 +995,6 @@ detailEl.addEventListener('click', async (e) => {
 			btn.textContent = 'Mark done';
 			btn.disabled = false;
 			showToast('Failed to update status');
-		}
-	}
-	if (e.target.matches('.edit-issue-btn')) {
-		const btn = e.target;
-		const currentIssue = ISSUES.find((i) => i.id === state.selected);
-		if (!currentIssue) return;
-
-		const newTitle = prompt('Edit Title:', currentIssue.title);
-		if (newTitle === null) return;
-		const newStatus = prompt('Edit Status (Open, In Progress, Resolved, Closed):', currentIssue.status);
-		if (newStatus === null) return;
-
-		const statusMap = {
-			open: 'Open',
-			'in-progress': 'In Progress',
-			'in progress': 'In Progress',
-			done: 'Resolved',
-			resolved: 'Resolved',
-			closed: 'Closed',
-		};
-		// Prompt input accepts user-friendly aliases but the API stores the
-		// canonical status labels used elsewhere in this file.
-		const normalisedStatus = statusMap[newStatus.trim().toLowerCase()] ?? newStatus.trim();
-
-		const updates = {
-			title: newTitle.trim() || currentIssue.title,
-			status: normalisedStatus || currentIssue.status,
-		};
-
-		btn.textContent = 'Saving...';
-		btn.disabled = true;
-		try {
-			await updateIssue(state.selected, updates);
-
-			const index = ISSUES.findIndex((i) => i.id === state.selected);
-			if (index !== -1) ISSUES[index] = { ...ISSUES[index], ...updates };
-
-			renderList();
-			renderDetail();
-			showToast('Issue updated');
-		} catch {
-			showToast('Failed to save edits');
-			btn.textContent = 'Edit';
-			btn.disabled = false;
 		}
 	}
 });

--- a/frontend/js/tracker.js
+++ b/frontend/js/tracker.js
@@ -89,7 +89,45 @@ confirmInviteBtn.addEventListener('click', async () => {
 });
 
 /**
- * Calculates issue counts and updates the sidebar UI
+ * Whether an issue matches a sidebar tag filter.
+ * @param {object} issue
+ * @param {string} tag
+ * @returns {boolean}
+ */
+function issueMatchesTag(issue, tag) {
+	if ((issue.tags || []).includes(tag)) return true;
+	if (tag === 'bug' && issue.category === 'Bug') return true;
+	return false;
+}
+
+/**
+ * Builds sidebar TAG filter rows from TAGS in constants.js.
+ */
+function renderTagFilters() {
+	const container = document.getElementById('tag-filters');
+	if (!container) return;
+
+	container.innerHTML = TAGS.map(
+		(t) => `
+		<div class="filter-item" data-group="tag" data-val="${t}">
+			<span class="indicator label-${t}"></span> ${t}
+			<span class="count" id="cnt-${t}">0</span>
+		</div>`,
+	).join('');
+}
+
+/**
+ * Populates the new-issue tag dropdown from TAGS.
+ */
+function populateNewTagSelect() {
+	const select = document.getElementById('new-tag');
+	if (!select) return;
+
+	select.innerHTML = TAGS.map((t) => `<option value="${t}">${t}</option>`).join('');
+}
+
+/**
+ * Gets issue counts and updates the sidebar UI
  * Reuses the fetched issue list so counts match the active team and filters.
  */
 function syncSidebar() {
@@ -107,23 +145,25 @@ function syncSidebar() {
 	safeSet('cnt-resolved', ISSUES.filter((i) => i.status === 'Resolved').length);
 	safeSet('cnt-closed', ISSUES.filter((i) => i.status === 'Closed').length);
 
-	// Tag counts drive sidebar filter badges (cnt-bug, cnt-feature, cnt-task).
+	// Tag counts drive sidebar filter badges (cnt-bug, cnt-ui, cnt-infra, cnt-auth, cnt-perf).
 	TAGS.forEach((t) => {
-		safeSet(`cnt-${t}`, ISSUES.filter((i) => (i.tags || []).includes(t)).length);
+		safeSet(`cnt-${t}`, ISSUES.filter((i) => issueMatchesTag(i, t)).length);
 	});
 }
 
-document.querySelectorAll('.sidebar .filter-item[data-group]').forEach((item) => {
-	item.addEventListener('click', () => {
+const sidebarEl = document.querySelector('.sidebar');
+if (sidebarEl) {
+	sidebarEl.addEventListener('click', (e) => {
+		const item = e.target.closest('.filter-item[data-group]');
+		if (!item) return;
+
 		const group = item.dataset.group;
 		const val = item.dataset.val;
 
-		// Toggle logic, if clicking the active one, reset to 'all'
 		if (state[group] === val) {
 			state[group] = 'all';
 			item.classList.remove('active');
 		} else {
-			// Remove active from sibling items in the same group
 			document.querySelectorAll(`.sidebar .filter-item[data-group="${group}"]`).forEach((el) => el.classList.remove('active'));
 			state[group] = val;
 			item.classList.add('active');
@@ -131,7 +171,10 @@ document.querySelectorAll('.sidebar .filter-item[data-group]').forEach((item) =>
 
 		renderList();
 	});
-});
+}
+
+renderTagFilters();
+populateNewTagSelect();
 
 /**
  * Filters, sorts, groups, and re-renders the issue list.
@@ -142,7 +185,7 @@ function renderList() {
 	let items = ISSUES.slice();
 
 	if (state.tag !== 'all') {
-		items = items.filter((i) => (i.tags || []).includes(state.tag));
+		items = items.filter((i) => issueMatchesTag(i, state.tag));
 	}
 	if (state.status !== 'all') {
 		// Each status filter maps to a single backend status value.

--- a/frontend/js/tracker.js
+++ b/frontend/js/tracker.js
@@ -1,16 +1,15 @@
-import { PRI_ORDER, STATUS_ORDER, PRI_LABEL, PRI_NAME, STATUS_NAME, SKILLS_MD } from './constants.js';
+import { PRI_ORDER, STATUS_ORDER, STATUS_NAME, SKILLS_MD, TAGS, TAG_MAP } from './constants.js';
 
 import { fetchIssues, createIssue, updateIssue } from './api.js';
 import { requireAuth, inviteToTeam, fetchTeams, fetchTeamMembers } from './api.js';
 
 requireAuth(); // forces the user to sign up if this page is accessed without credentials
 
-// STATE
+// Sidebar filters: status + tag only (priority is sortable, not filterable here).
 const state = {
 	sort: 'priority',
 	tag: 'all',
 	status: 'all',
-	priority: 'all',
 	query: '',
 	selected: null,
 	detailOpen: true,
@@ -105,14 +104,11 @@ function syncSidebar() {
 
 	safeSet('cnt-open', ISSUES.filter((i) => i.status === 'Open').length);
 	safeSet('cnt-prog', ISSUES.filter((i) => i.status === 'In Progress').length);
-	safeSet('cnt-done', ISSUES.filter((i) => ['Resolved', 'Closed'].includes(i.status)).length);
+	safeSet('cnt-resolved', ISSUES.filter((i) => i.status === 'Resolved').length);
+	safeSet('cnt-closed', ISSUES.filter((i) => i.status === 'Closed').length);
 
-	safeSet('cnt-crit', ISSUES.filter((i) => i.priority === 'Critical').length);
-	safeSet('cnt-high', ISSUES.filter((i) => i.priority === 'High').length);
-	safeSet('cnt-med', ISSUES.filter((i) => i.priority === 'Medium').length);
-	safeSet('cnt-low', ISSUES.filter((i) => i.priority === 'Low').length);
-
-	['bug', 'ui', 'infra', 'auth', 'perf'].forEach((t) => {
+	// Tag counts drive sidebar filter badges (cnt-bug, cnt-feature, cnt-task).
+	TAGS.forEach((t) => {
 		safeSet(`cnt-${t}`, ISSUES.filter((i) => (i.tags || []).includes(t)).length);
 	});
 }
@@ -149,22 +145,14 @@ function renderList() {
 		items = items.filter((i) => (i.tags || []).includes(state.tag));
 	}
 	if (state.status !== 'all') {
-		if (state.status === 'Resolved') {
-			items = items.filter((i) => ['Resolved', 'Closed'].includes(i.status));
-		} else {
-			items = items.filter((i) => i.status === state.status);
-		}
-	}
-	if (state.priority !== 'all') {
-		items = items.filter((i) => i.priority === state.priority);
+		// Each status filter maps to a single backend status value.
+		items = items.filter((i) => i.status === state.status);
 	}
 
 	if (state.sort === 'priority') {
 		items.sort((a, b) => PRI_ORDER[a.priority] - PRI_ORDER[b.priority] || STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
 	} else if (state.sort === 'updated') {
 		items.sort((a, b) => ISSUES.indexOf(a) - ISSUES.indexOf(b));
-	} else if (state.sort === 'difficulty') {
-		items.sort((a, b) => b.difficulty - a.difficulty);
 	}
 
 	totalCountEl.textContent = items.length;
@@ -180,14 +168,6 @@ function renderList() {
 			{ label: 'Medium', rows: buckets.Medium },
 			{ label: 'Low', rows: buckets.Low },
 		].filter((g) => g.rows.length);
-	} else if (state.sort === 'difficulty') {
-		const map = {};
-		items.forEach((i) => {
-			const k = `Difficulty ${i.difficulty}`;
-			if (!map[k]) map[k] = [];
-			map[k].push(i);
-		});
-		groups = Object.entries(map).map(([label, rows]) => ({ label, rows }));
 	} else {
 		groups = [{ label: 'Most recent', rows: items }];
 	}
@@ -297,8 +277,8 @@ function renderTeamMembers() {
 }
 
 // === Date Formatting === //
-/** 
- * @param {string | null | undefined} value
+/**
+ * @param {string | null | undefined} value - Raw timestamp from the API.
  * @returns {Date | null}
  */
 function parseIssueTimestamp(value) {
@@ -309,7 +289,7 @@ function parseIssueTimestamp(value) {
 }
 
 /**
- * @param {string | null | undefined} value
+ * @param {string | null | undefined} value - Raw timestamp from the API.
  * @returns {string}
  */
 function formatIssueDate(value) {
@@ -328,7 +308,7 @@ function formatIssueDate(value) {
 }
 
 /**
- * @param {string | null | undefined} value
+ * @param {string | null | undefined} value - Raw timestamp from the API.
  * @returns {string}
  */
 function formatIssueDateTime(value) {
@@ -349,25 +329,21 @@ function formatIssueDateTime(value) {
 
 /**
  * Escape user/LLM text before inserting into detail pane HTML.
- * @param {string} text
+ * @param {string} text - Raw text to escape.
  * @returns {string}
  */
 function escapeHtml(text) {
-	return String(text)
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+	return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 /**
  * Plain-text section body with fallback when LLM/user field is empty.
- * @param {string | null | undefined} value
- * @param {string} [fallback='Not available yet']
+ * @param {string | null | undefined} value - Field value from the issue record.
+ * @param {string} [fallback='Not available yet'] - Text shown when value is empty.
  * @returns {string}
  */
 function formatIssueText(value, fallback = 'Not available yet') {
-	if (value == null) return fallback;
+	if (value === null || value === undefined) return fallback;
 	const text = (typeof value === 'string' ? value : String(value)).trim();
 	if (!text || text.toLowerCase() === 'null') return fallback;
 	return escapeHtml(text);
@@ -375,8 +351,8 @@ function formatIssueText(value, fallback = 'Not available yet') {
 
 /**
  * Merges LLM-enriched fields from POST /issues into an in-memory issue record.
- * @param {object} issue
- * @param {object} enriched
+ * @param {object} issue - Existing in-memory issue record.
+ * @param {object} enriched - LLM fields returned by the API.
  * @returns {object}
  */
 function applyEnrichedFields(issue, enriched) {
@@ -390,11 +366,11 @@ function applyEnrichedFields(issue, enriched) {
 
 /**
  * Render steps_to_reproduce — API may store plain text or a JSON array string.
- * @param {string | string[] | null | undefined} value
+ * @param {string | string[] | null | undefined} value - Steps field from the issue record.
  * @returns {string}
  */
 function formatStepsToReproduce(value) {
-	if (value == null || value === '') return 'Not available yet';
+	if (value === null || value === undefined || value === '') return 'Not available yet';
 
 	let steps = value;
 	if (typeof value === 'string') {
@@ -418,6 +394,19 @@ function formatStepsToReproduce(value) {
 }
 
 /**
+ * Resolve the primary tag for an issue from tags or legacy category.
+ * @param {object} issue - Issue record from the API.
+ * @returns {string}
+ */
+function getIssueTag(issue) {
+	const tag = (issue.tags || []).find((t) => TAGS.includes(t));
+	if (tag) return tag;
+	const cat = issue.category?.toLowerCase();
+	if (TAGS.includes(cat)) return cat;
+	return 'bug';
+}
+
+/**
  * Build HTML for a single issue row in the list.
  * @param {object} i - Issue record.
  * @returns {string} HTML string for the row.
@@ -428,8 +417,8 @@ function rowHtml(i) {
 
 	// Tag Shrink Logic
 	const maxTags = 2;
-	const visibleTags = i.tags.slice(0, maxTags);
-	const moreCount = i.tags.length - maxTags;
+	const visibleTags = (i.tags || []).slice(0, maxTags);
+	const moreCount = (i.tags || []).length - maxTags;
 
 	const tagsHtml =
 		visibleTags.map((l) => `<span class="chip tag-${l}">${l}</span>`).join('') +
@@ -437,7 +426,6 @@ function rowHtml(i) {
 
 	return `
 	<div class="issue-row ${isSel ? 'selected' : ''}" data-id="${i.id}">
-		<span class="pri-mark ${i.priority.toLowerCase()}" title="${PRI_NAME[i.priority]}">${PRI_LABEL[i.priority]}</span>
 		<div class="title">
 			<span>${i.title}</span>
 			<span class="sub">${i.summary || ''}</span>
@@ -489,13 +477,9 @@ function renderDetail() {
 					<span class="chip sm"><span class="dot" style="background:var(--pri-${i.priority.toLowerCase()})"></span>${i.priority}</span>
 				</div>
 				<div class="meta-col">
-					<span class="label-sm">DIFFICULTY</span>
-					<div class="diff">${Array.from({ length: 3 }, (_, k) => `<span class="d ${k < i.difficulty ? 'on' : ''}"></span>`).join('')}</div>
-				</div>
-				<div class="meta-col">
 					<span class="label-sm">LABELS</span>
 					<div class="tag-container">
-						${i.tags.map((t) => `<span class="chip sm">${t}</span>`).join('')}
+						${(i.tags || []).map((t) => `<span class="chip sm tag-${t}">${t}</span>`).join('')}
 					</div>
 				</div>
 				<div class="meta-col">
@@ -550,6 +534,12 @@ function renderDetail() {
 						<option ${i.priority === 'High' ? 'selected' : ''}>High</option>
 						<option ${i.priority === 'Medium' ? 'selected' : ''}>Medium</option>
 						<option ${i.priority === 'Low' ? 'selected' : ''}>Low</option>
+					</select>
+				</div>
+				<div class="meta-col">
+					<span class="label-sm">TAG</span>
+					<select class="input sm" id="edit-tag">
+						${TAGS.map((t) => `<option value="${t}" ${getIssueTag(i) === t ? 'selected' : ''}>${t}</option>`).join('')}
 					</select>
 				</div>
 			</div>
@@ -806,16 +796,15 @@ confirmNewBtn.addEventListener('click', async () => {
 	if (state.currentTeamId) formData.append('team_id', state.currentTeamId);
 
 	const priority = document.getElementById('new-priority')?.value;
-	const category = document.getElementById('new-category')?.value;
+	const tag = document.getElementById('new-tag')?.value;
 	const assignee = document.getElementById('new-assignee')?.value;
-	const difficulty = document.getElementById('new-difficulty')?.value;
-	const tags = document.getElementById('new-tags')?.value;
 
 	if (priority) formData.append('priority', priority);
-	if (category) formData.append('category', category);
+	if (tag) {
+		formData.append('tags', tag);
+		formData.append('category', TAG_MAP[tag]);
+	}
 	if (assignee) formData.append('assigned_to', assignee);
-	if (difficulty) formData.append('difficulty', difficulty);
-	if (tags) formData.append('tags', tags);
 
 	pendingFiles.forEach((f) => formData.append('attachments', f));
 
@@ -938,6 +927,7 @@ detailEl.addEventListener('click', async (e) => {
 		const title = document.getElementById('edit-title')?.value.trim();
 		const status = document.getElementById('edit-status')?.value;
 		const priority = document.getElementById('edit-priority')?.value;
+		const tag = document.getElementById('edit-tag')?.value;
 		const description = document.getElementById('edit-desc')?.value.trim();
 
 		if (!title || !description) {
@@ -945,7 +935,7 @@ detailEl.addEventListener('click', async (e) => {
 			return;
 		}
 
-		const updates = { title, status, priority, description };
+		const updates = { title, status, priority, description, tags: [tag], category: TAG_MAP[tag] };
 
 		saveBtn.textContent = 'Saving...';
 		saveBtn.disabled = true;

--- a/issue-tracker-api/test/invites.spec.js
+++ b/issue-tracker-api/test/invites.spec.js
@@ -2,6 +2,9 @@ import { env, SELF } from 'cloudflare:test';
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import sqlSchemaRaw from '../schema.sql?raw';
 
+/**
+ *
+ */
 async function cleanDatabase() {
 	await env.DB.exec(`
     DELETE FROM sessions;
@@ -13,6 +16,11 @@ async function cleanDatabase() {
   `);
 }
 
+/**
+ *
+ * @param username
+ * @param email
+ */
 async function createTestUser(username, email) {
 	const row = await env.DB.prepare(
 		`INSERT INTO users (username, first_name, last_name, email, password_hash)
@@ -23,6 +31,12 @@ async function createTestUser(username, email) {
 	return row.id;
 }
 
+/**
+ *
+ * @param userId
+ * @param token
+ * @param ttlHours
+ */
 async function createTestSession(userId, token, ttlHours = 24) {
 	const expiryDate = new Date();
 	expiryDate.setHours(expiryDate.getHours() + ttlHours);
@@ -31,6 +45,11 @@ async function createTestSession(userId, token, ttlHours = 24) {
 		.run();
 }
 
+/**
+ *
+ * @param teamName
+ * @param creatorId
+ */
 async function createTestTeam(teamName, creatorId = null) {
 	const row = await env.DB.prepare(`INSERT INTO teams (team_name) VALUES (?) RETURNING id`).bind(teamName).first();
 	const teamId = row.id;
@@ -42,10 +61,23 @@ async function createTestTeam(teamName, creatorId = null) {
 	return teamId;
 }
 
+/**
+ *
+ * @param userId
+ * @param teamId
+ * @param role
+ */
 async function createTeamMembership(userId, teamId, role = 'member') {
 	await env.DB.prepare('INSERT INTO team_members (team_id, user_id, role) VALUES (?, ?, ?)').bind(teamId, userId, role).run();
 }
 
+/**
+ *
+ * @param teamId
+ * @param inviterId
+ * @param invitedId
+ * @param status
+ */
 async function createTestInvite(teamId, inviterId, invitedId, status = 'pending') {
 	const row = await env.DB.prepare(
 		`INSERT INTO invites (team_id, inviter_user_id, invited_user_id, status, created_at)
@@ -56,6 +88,10 @@ async function createTestInvite(teamId, inviterId, invitedId, status = 'pending'
 	return row.id;
 }
 
+/**
+ *
+ * @param token
+ */
 function authHeaders(token) {
 	return {
 		Authorization: `Bearer ${token}`,


### PR DESCRIPTION
- Status filters now match backend exactly: Open, In Progress, Resolved, and Closed 
- Sidebar filters are status + tag only
- Tags standardized to bug, feature, and task to match backend
- Removed difficulty from forms, detail view, and sort options
